### PR TITLE
Feat/master/extra logging

### DIFF
--- a/idsvr/README.md
+++ b/idsvr/README.md
@@ -55,11 +55,13 @@ Parameter | Description | Default
 `curity.admin.service.port`| The admin configuration port |`6789`
 `curity.admin.logging.stdout`| Flag to enable/disable extra containers that tail the logs in `var/log` folder. |`false`
 `curity.admin.logging.logs`| Array of the extra containers that will be included in the admin pod |`[]`
+`curity.admin.logging.image`| The image that will be used to create the logging containers |`busybox:latest`
 `curity.runtime.role`| The role of the runtime servers |`default`
 `curity.runtime.service.type`| The runtime service type |`ClusterIP`
 `curity.runtime.service.port`| The runtime service port |`8443`
 `curity.runtime.logging.stdout`| Flag to enable/disable extra containers that tail the logs in `var/log` folder. |`false`
 `curity.runtime.logging.logs`| Array of the extra containers that will be included in the runtime pods |`[]`
+`curity.runtime.logging.image`| The image that will be used to create the logging containers |`busybox:latest`
 `curity.config.uiEnabled`| Flag to enable/disable the service for Admin UI and Admin REST API |`false`
 `curity.config.password`| The administrator password. Required if `curity.config.environmentVariableSecret` and `curity.config.configurationSecret` is not set | `null`
 `curity.config.encryptionKey`| The configuration encryption key |`null`

--- a/idsvr/README.md
+++ b/idsvr/README.md
@@ -113,7 +113,7 @@ helm upgrade <release-name> curity/idsvr \
 ## Sending all logs to stdout
 
 If `curity.admin.logging.sdtout` is `true`, the Chart will add extra containers in the pods, that will tail any additional log files defined in `curity.admin.logging.logs` and pipe them to stdout.
-The same applies for `curity.admin.logging.sdtout`.
+The same applies for `curity.runtime.logging.sdtout`.
 
 ## More Information
 

--- a/idsvr/README.md
+++ b/idsvr/README.md
@@ -53,9 +53,13 @@ Parameter | Description | Default
 `curity.admin.role`| The role of the admin server |`admin`
 `curity.admin.service.type`| The admin service type |`ClusterIP`
 `curity.admin.service.port`| The admin configuration port |`6789`
+`curity.admin.logging.stdout`| Flag to enable/disable extra containers that tail the logs in `var/log` folder. |`false`
+`curity.admin.logging.logs`| Array of the extra containers that will be included in the admin pod |`[]`
 `curity.runtime.role`| The role of the runtime servers |`default`
 `curity.runtime.service.type`| The runtime service type |`ClusterIP`
 `curity.runtime.service.port`| The runtime service port |`8443`
+`curity.runtime.logging.stdout`| Flag to enable/disable extra containers that tail the logs in `var/log` folder. |`false`
+`curity.runtime.logging.logs`| Array of the extra containers that will be included in the runtime pods |`[]`
 `curity.config.uiEnabled`| Flag to enable/disable the service for Admin UI and Admin REST API |`false`
 `curity.config.password`| The administrator password. Required if `curity.config.environmentVariableSecret` and `curity.config.configurationSecret` is not set | `null`
 `curity.config.encryptionKey`| The configuration encryption key |`null`
@@ -104,6 +108,12 @@ helm upgrade <release-name> curity/idsvr \
   --set curity.config.configurationSecret=SECRET_NAME \
   --set curity.config.configurationSecretItemName=<DATE>-<TRANSACTION_ID>.xml
 ``` 
+
+
+## Sending all logs to stdout
+
+If `curity.admin.logging.sdtout` is `true`, the Chart will add extra containers in the pods, that will tail any additional log files defined in `curity.admin.logging.logs` and pipe them to stdout.
+The same applies for `curity.admin.logging.sdtout`.
 
 ## More Information
 

--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -119,7 +119,7 @@ spec:
         - name: backup-config-script
           configMap:
             name: {{ include "curity.fullname" . }}-backup-config-script
-            defaultMode: 705
+            defaultMode: 0705
             items:
               - key: backupConfig.sh
                 path: backupConfig.sh

--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -1,3 +1,4 @@
+{{- $root := . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -72,6 +73,10 @@ spec:
               port: health-check
             initialDelaySeconds: 30
           volumeMounts:
+            {{- if .Values.curity.admin.logging.stdout }}
+            - mountPath: /opt/idsvr/var/log/
+              name: log-volume
+            {{- end }}
             - mountPath: /opt/idsvr/etc/init/cluster.xml
               subPath: cluster.xml
               name: cluster-xml
@@ -96,11 +101,29 @@ spec:
             {{- end }}
           resources:
                 {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.curity.admin.logging.stdout }}
+        {{- range .Values.curity.admin.logging.logs }}
+        - name: {{ . }}
+          image: busybox
+          command:
+            - "tail"
+            - "-F"
+            - "/log/{{ . | lower }}.log"
+          volumeMounts:
+            - name: log-volume
+              mountPath: /log
+              readOnly: true
+      {{- end }}
+      {{- end }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret}}
       {{- end }}
       volumes:
+        {{- if .Values.curity.admin.logging.stdout }}
+        - name: log-volume
+          emptyDir: {}
+        {{- end }}
         - name: cluster-xml
           secret:
             secretName: {{ include "curity.fullname" . }}-cluster-config-xml

--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -104,7 +104,7 @@ spec:
         {{- if .Values.curity.admin.logging.stdout }}
         {{- range .Values.curity.admin.logging.logs }}
         - name: {{ . }}
-          image: busybox
+          image: {{ $root.Values.curity.admin.logging.image }}
           command:
             - "tail"
             - "-F"

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -1,3 +1,4 @@
+{{- $root := . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -58,6 +59,10 @@ spec:
               port: health-check
             initialDelaySeconds: 30
           volumeMounts:
+            {{- if .Values.curity.runtime.logging.stdout }}
+            - mountPath: /opt/idsvr/var/log/
+              name: log-volume
+            {{- end }}
             - mountPath: /opt/idsvr/etc/init/cluster.xml
               subPath: cluster.xml
               name: cluster-xml
@@ -76,11 +81,29 @@ spec:
             {{- end }}
           resources:
                 {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.curity.runtime.logging.stdout }}
+        {{- range .Values.curity.runtime.logging.logs }}
+        - name: {{ . }}
+          image: busybox
+          command:
+            - "tail"
+            - "-F"
+            - "/log/{{ . | lower }}.log"
+          volumeMounts:
+            - name: log-volume
+              mountPath: /log
+              readOnly: true
+        {{- end }}
+        {{- end }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret}}
       {{- end }}
       volumes:
+        {{- if .Values.curity.runtime.logging.stdout }}
+        - name: log-volume
+          emptyDir: {}
+        {{- end }}
         - name: cluster-xml
           secret:
             secretName: {{ include "curity.fullname" . }}-cluster-config-xml

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -84,7 +84,7 @@ spec:
         {{- if .Values.curity.runtime.logging.stdout }}
         {{- range .Values.curity.runtime.logging.logs }}
         - name: {{ . }}
-          image: busybox
+          image: {{ $root.Values.curity.runtime.logging.image }}
           command:
             - "tail"
             - "-F"

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -25,6 +25,7 @@ curity:
       type: ClusterIP
       port: 6789
     logging:
+      image: "busybox:latest"
       stdout: false
       logs: []
 #        - audit
@@ -41,6 +42,7 @@ curity:
       type: ClusterIP
       port: 8443
     logging:
+      image: "busybox:latest"
       stdout: false
       logs: []
 #        - audit

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -24,12 +24,34 @@ curity:
     service:
       type: ClusterIP
       port: 6789
+    logging:
+      stdout: false
+      logs: []
+#        - audit
+#        - request
+#        - cluster
+#        - confsvc
+#        - confsvc-audit
+#        - confsvc-internal
+#        - confsvc-browser
+#        - post-commit-scripts
+
 
   runtime:
     role: default
     service:
       type: ClusterIP
       port: 8443
+    logging:
+      stdout: false
+      logs: []
+#        - audit
+#        - request
+#        - cluster
+#        - confsvc
+#        - confsvc-audit
+#        - confsvc-internal
+#        - post-commit-scripts
 
   config:
     uiEnabled: false

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -31,9 +31,7 @@ curity:
 #        - request
 #        - cluster
 #        - confsvc
-#        - confsvc-audit
 #        - confsvc-internal
-#        - confsvc-browser
 #        - post-commit-scripts
 
 
@@ -49,7 +47,6 @@ curity:
 #        - request
 #        - cluster
 #        - confsvc
-#        - confsvc-audit
 #        - confsvc-internal
 #        - post-commit-scripts
 


### PR DESCRIPTION
This PR adds the option to enable extra logging by setting `curity.admin.logging.sdtout` to `true` and configuring which logs to tail in the `curity.admin.logging.logs` array. 

_Similar options for `runtime` pods._