### PR TITLE
Support configuration using startup.properties

### DIFF
--- a/idsvr/README.md
+++ b/idsvr/README.md
@@ -88,13 +88,15 @@ Parameter | Description | Default
 `curity.runtime.logging.logs`| Array of the extra containers that will be included in the runtime pods |`[]`
 `curity.runtime.logging.image`| The image that will be used to create the logging containers |`busybox:latest`
 `curity.config.uiEnabled`| Flag to enable/disable the service for Admin UI and Admin REST API |`false`
-`curity.config.password`| The administrator password. Required if `curity.config.environmentVariableSecret` and `curity.config.configurationSecret` is not set | `null`
+`curity.config.password`| The administrator password. Required if none of `curity.config.environmentVariableSecret`, `curity.config.configurationSecret`, and `curity.config.startupProperties` is set | `null`
 `curity.config.encryptionKey`| The configuration encryption key |`null`
 `curity.config.environmentVariableSecret`| The data from this Secret will be mounted as environment variables |`null`
 `curity.config.configurationSecret`| The Secret containing configuration which is mounted as a volume  |`null`
 `curity.config.configurationSecretItemName`| The `curity.config.configurationSecret`'s item name, required if the Secret is set. |`null`
 `curity.config.configurationConfigMap`| The ConfigMap containing configuration which is mounted as a volume  |`null`
 `curity.config.configurationConfigMapItemName`| The `curity.config.configurationConfigMap`'s item name, required if the ConfigMap is set. |`null`
+`curity.config.startupProperties`| The Secret containing `startup.properties` which is mounted as a volume  |`null`
+`curity.config.startupPropertiesItemName`| The `curity.config.startupProperties`'s item name, required if the Secret is set. |`null`
 `curity.config.backup` | If `true`, the configuration will be backed up in a secret in each commit | `false` 
 `ingress.enabled`| Flag to enable/disable an Ingress resource |`false`
 `ingress.annotations`| Extra annotations for the Ingress resource   |`{}`

--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -42,7 +42,7 @@ spec:
               value: {{ .Values.curity.admin.logging.level }}
             - name: ADMIN_UI_HTTP_MODE
               value: {{ quote .Values.curity.adminUiHttp }}
-          {{- if not (or (.Values.curity.config.environmentVariableSecret) (.Values.curity.config.configurationSecret)) }}
+          {{- if not (or (.Values.curity.config.environmentVariableSecret) (.Values.curity.config.configurationSecret) (.Values.curity.config.startupPropertiesSecret)) }}
             - name: PASSWORD
               value: {{ required "\n curity.config.password required! use --set curity.config.password=YOUR_PASSWORD" .Values.curity.config.password | quote }}
           {{- end }}
@@ -108,6 +108,12 @@ spec:
               name: config
               readOnly: true
             {{- end }}
+            {{- if .Values.curity.config.startupPropertiesSecret }}
+            - mountPath: /opt/idsvr/etc/startup.properties
+              subPath: startup.properties
+              name: startup-properties
+              readOnly: true
+            {{- end }}
             {{- if .Values.curity.config.configurationConfigMap }}
             - mountPath: /opt/idsvr/etc/init/configmap-config.xml
               subPath: {{ required "\n curity.config.configurationConfigMapItemName required when curity.config.configurationConfigMap is set. " .Values.curity.config.configurationConfigMapItemName }}
@@ -152,6 +158,14 @@ spec:
             items:
               - key: {{ required "\n curity.config.configurationSecretItemName required when curity.config.configurationSecret is set. " .Values.curity.config.configurationSecretItemName }}
                 path: config.xml
+        {{- end }}
+        {{- if .Values.curity.config.startupPropertiesSecret }}
+        - name: startup-properties
+          secret:
+            secretName: {{ .Values.curity.config.startupPropertiesSecret }}
+            items:
+              - key: {{ required "\n curity.config.startupPropertiesSecretItemName required when curity.config.startupPropertiesSecret is set. " .Values.curity.config.startupPropertiesSecretItemName }}
+                path: startup.properties
         {{- end }}
         {{- if .Values.curity.config.backup }}
         - name: backup-config-script

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -82,6 +82,12 @@ spec:
               name: config
               readOnly: true
             {{- end }}
+            {{- if .Values.curity.config.startupPropertiesSecret }}
+            - mountPath: /opt/idsvr/etc/startup.properties
+              subPath: startup.properties
+              name: startup-properties
+              readOnly: true
+            {{- end }}
             {{- if .Values.curity.config.configurationConfigMap }}
             - mountPath: /opt/idsvr/etc/init/configmap-config.xml
               subPath: {{ required "\n curity.config.configurationConfigMapItemName required when curity.config.configurationConfigMap is set. " .Values.curity.config.configurationConfigMapItemName }}
@@ -126,6 +132,14 @@ spec:
             items:
               - key: {{ required "\n curity.config.configurationSecretItemName required when curity.config.configurationSecret is set. " .Values.curity.config.configurationSecretItemName }}
                 path: config.xml
+        {{- end }}
+        {{- if .Values.curity.config.startupPropertiesSecret }}
+        - name: startup-properties
+          secret:
+            secretName: {{ .Values.curity.config.startupPropertiesSecret }}
+            items:
+              - key: {{ required "\n curity.config.startupPropertiesSecretItemName required when curity.config.startupPropertiesSecret is set. " .Values.curity.config.startupPropertiesSecretItemName }}
+                path: startup.properties
         {{- end }}
         {{- if .Values.curity.config.configurationConfigMap }}
         - name: configmap-config

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -89,6 +89,8 @@ curity:
     configurationConfigMapItemName:
     configurationSecret:
     configurationSecretItemName:
+    startupPropertiesSecret:
+    startupPropertiesSecretItemName:
 
 
 ingress:


### PR DESCRIPTION
@travisspencer @anestos I know `startup.properties` is not mentioned a lot in the curity docs, but this is the way we've chosen to specify config values for now (cos it's simpler when using something like [sops](https://github.com/mozilla/sops)). Does it belong here?