### PR TITLE
Custom Environment Variables Support

### DIFF
--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -50,6 +50,10 @@ spec:
             - name: SECRET_NAME
               value: {{ include "curity.fullname" . }}-config-backup
           {{- end }}
+          {{- range $env := .Values.curity.admin.extraEnv }}
+            - name: {{ $env.name }}
+              value: {{ $env.value | quote }}
+          {{- end }}
           {{- if .Values.curity.config.environmentVariableSecret }}
           envFrom:
             - secretRef:

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -12,7 +12,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "curity.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      role: {{ include "curity.fullname" . }}-runtime
   template:
     metadata:
       labels:
@@ -36,6 +35,10 @@ spec:
               value: {{ .Values.curity.healthCheckPort | quote }}
             - name: LOGGING_LEVEL
               value: {{ .Values.curity.runtime.logging.level }}
+            {{- range $env := .Values.curity.runtime.extraEnv }}
+            - name: {{ $env.name }}
+              value: {{ $env.value | quote }}
+            {{- end }}
           {{- if .Values.curity.config.environmentVariableSecret }}
           envFrom:
             - secretRef:
@@ -43,7 +46,7 @@ spec:
           {{- end }}
           ports:
             - name: http-port
-              containerPort: {{ .Values.curity.runtime.deployment.port }}
+              containerPort: {{ .Values.curity.runtime.service.port }}
               protocol: TCP
             - name: health-check
               containerPort: {{ .Values.curity.healthCheckPort }}

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -12,6 +12,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "curity.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      role: {{ include "curity.fullname" . }}-runtime
   template:
     metadata:
       labels:
@@ -46,7 +47,7 @@ spec:
           {{- end }}
           ports:
             - name: http-port
-              containerPort: {{ .Values.curity.runtime.service.port }}
+              containerPort: {{ .Values.curity.runtime.deployment.port }}
               protocol: TCP
             - name: health-check
               containerPort: {{ .Values.curity.healthCheckPort }}

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: curity.azurecr.io/curity/idsvr
-  tag: 6.2.2
+  tag: 6.1.0
   pullPolicy: IfNotPresent
   pullSecret:
 
@@ -36,6 +36,12 @@ curity:
       successThreshold: 3
       periodSeconds: 10
       initialDelaySeconds: 30
+    # extraEnv provides additional environment variables
+    # extraEnv:
+    #   - name: SOME_EXTRA_VARIABLE
+    #     value: "extra-variable-value"
+    extraEnv: []
+
     logging:
       level: INFO
       image: "busybox:latest"
@@ -54,8 +60,6 @@ curity:
     service:
       type: ClusterIP
       port: 8443
-    deployment:
-      port: 8443
     livenessProbe:
       timeoutSeconds: 1
       failureThreshold: 3
@@ -67,6 +71,11 @@ curity:
       successThreshold: 3
       periodSeconds: 10
       initialDelaySeconds: 30
+    # extraEnv provides additional environment variables
+    # extraEnv:
+    #   - name: SOME_EXTRA_VARIABLE
+    #     value: "extra-variable-value"
+    extraEnv: []
     logging:
       level: INFO
       image: "busybox:latest"
@@ -100,8 +109,6 @@ ingress:
   runtime:
     host: curity.local
     secretName:
-    paths:
-      - /
   admin:
     host: curity-admin.local
     secretName:

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: curity.azurecr.io/curity/idsvr
-  tag: 6.1.0
+  tag: 6.2.2
   pullPolicy: IfNotPresent
   pullSecret:
 
@@ -60,6 +60,8 @@ curity:
     service:
       type: ClusterIP
       port: 8443
+    deployment:
+      port: 8443
     livenessProbe:
       timeoutSeconds: 1
       failureThreshold: 3
@@ -109,6 +111,8 @@ ingress:
   runtime:
     host: curity.local
     secretName:
+    paths:
+      - /
   admin:
     host: curity-admin.local
     secretName:


### PR DESCRIPTION
This PR adds the variable `extraEnv` where the user can provide a list of environment variables for admin and runtime.

### Usecases

Add environment variables for custom commit scripts