### PR TITLE
Remove deployment commands

### DIFF
--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -26,8 +26,8 @@ spec:
         - name: {{ .Chart.Name }}-admin
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/opt/idsvr/bin/idsvr"]
-          args: ["-s", "{{ .Values.curity.admin.role }}",
+          args: ["/opt/idsvr/bin/idsvr",
+                 "-s", "{{ .Values.curity.admin.role }}",
                  "-N", "{{ .Chart.Name }}-admin",
                  {{- if .Values.curity.config.encryptionKey}}"-e","{{.Values.curity.config.encryptionKey}}",{{end -}}
                  "--admin"]

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -27,8 +27,8 @@ spec:
         - name: {{ .Chart.Name }}-runtime
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/opt/idsvr/bin/idsvr"]
-          args: ["-s", "{{ .Values.curity.runtime.role }}",
+          args: ["/opt/idsvr/bin/idsvr",
+                 "-s", "{{ .Values.curity.runtime.role }}",
                  {{- if .Values.curity.config.encryptionKey}}"-e","{{.Values.curity.config.encryptionKey}}",{{end -}}
                  "--no-admin"]
           env:


### PR DESCRIPTION
Specifying a command is unnecessary and takes away the ability to use a docker entrypoint.

From [k8s docs](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#notes):
> If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.