### PR TITLE
Added a role label to services as required by service monitor for aut…

### DIFF
--- a/idsvr/templates/service-admin.yaml
+++ b/idsvr/templates/service-admin.yaml
@@ -3,7 +3,8 @@ kind: Service
 metadata:
   name: {{ include "curity.fullname" . }}-admin-svc
   labels:
-        {{- include "curity.labels" . | nindent 4 }}
+    {{- include "curity.labels" . | nindent 4 }}
+    role: {{ include "curity.fullname" . }}-admin
 spec:
   type: {{ .Values.curity.admin.service.type }}
   ports:

--- a/idsvr/templates/service-runtime.yaml
+++ b/idsvr/templates/service-runtime.yaml
@@ -3,7 +3,8 @@ kind: Service
 metadata:
   name: {{ include "curity.fullname" . }}-runtime-svc
   labels:
-        {{- include "curity.labels" . | nindent 4 }}
+    {{- include "curity.labels" . | nindent 4 }}
+    role: {{ include "curity.fullname" . }}-runtime
 spec:
   type: {{ .Values.curity.runtime.service.type }}
   ports:


### PR DESCRIPTION
Prometheus comes with a custom Kubernetes resource called service monitor. This can be used to feed metrics from the metrics endpoint of the Curity Identity Server into Prometheus. By default I would specify this:

```
kind: ServiceMonitor
apiVersion: monitoring.coreos.com/v1
metadata:
  name: curity-idsvr-runtime
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: idsvr
  endpoints:
    - port: metrics
``` 

But this matches both Admin and Runtime services for each pod, causing metrics entries to be duplicated, and the data is wrong:

![nodes-in-prometheus](https://user-images.githubusercontent.com/32388530/131669316-880884d2-7530-4113-baaf-a25be06cb6f9.png)

It feels like the only good way to solve this problem is via labels, which is the only option service monitors support:

```
kind: ServiceMonitor
apiVersion: monitoring.coreos.com/v1
metadata:
  name: curity-idsvr-runtime
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: idsvr
      role: curity-idsvr-runtime
  endpoints:
    - port: metrics
``` 

Writing an extra service label for all customers is what I've done so far, though I could change what I've done to derive from a new `custom labels` setting in the values file if reviewers prefer that option.