### PR TITLE
migrate to v1 since v1beta1 is no longer served

### DIFF
--- a/idsvr/templates/ingress.yaml
+++ b/idsvr/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "curity.fullname" . }}-ingress
@@ -29,17 +29,23 @@ spec:
         paths:
           {{- range .Values.ingress.runtime.paths }}
           - path: {{ . }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ include "curity.fullname" $ }}-runtime-svc
-              servicePort: http-port
+              service:
+                name: {{ include "curity.fullname" $ }}-runtime-svc
+                port:
+                  name: http-port
           {{- end }}
   {{- if .Values.curity.config.uiEnabled }}
     - host: {{ .Values.ingress.admin.host }}
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ include "curity.fullname" . }}-admin-svc
-              servicePort: admin-ui
+              service:
+                name: {{ include "curity.fullname" . }}-admin-svc
+                port:
+                  name: admin-ui
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Updates the helm chart according to guidelines in https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122