### PR TITLE
Fix Conf Job Role & RoleBinding timing

### DIFF
--- a/idsvr/templates/rbac.yaml
+++ b/idsvr/templates/rbac.yaml
@@ -14,6 +14,9 @@ metadata:
   name: {{ include "curity.fullname" . }}-create-secret
   labels:
         {{- include "curity.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
 rules:
   - apiGroups:
       - ""
@@ -28,6 +31,9 @@ metadata:
   name: {{ include "curity.fullname" . }}-role-binding
   labels:
         {{- include "curity.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
Fixes an issue where the conf job could fail with an an Unauthorized error due to the service account not having proper permissions:

```
depth=1 CN = kubernetes
verify return:1
depth=0 CN = kube-apiserver
verify return:1
HTTP/1.1 403 Forbidden
Audit-Id: e1b63eb0-de77-482a-91c7-e7e6efd23460
Cache-Control: no-cache, private
Content-Type: application/json
X-Content-Type-Options: nosniff
Date: Wed, 06 Oct 2021 17:35:15 GMT
Content-Length: 434
Connection: close

{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"secrets \"identity-server-test-cluster-config-xml\" is forbidden: User \"system:serviceaccount:identity-dev-test:identity-server-test-service-account\" cannot patch resource \"secrets\" in API group \"\" in the namespace \"identity-dev-test\"","reason":"Forbidden","details":{"name":"identity-server-test-cluster-config-xml","kind":"secrets"},"code":403}
```