### PR TITLE
Support multiple files in configuration configmap

### DIFF
--- a/idsvr/README.md
+++ b/idsvr/README.md
@@ -96,7 +96,9 @@ Parameter | Description | Default
 `curity.config.configurationSecret`| The Secret containing configuration which is mounted as a volume  |`null`
 `curity.config.configurationSecretItemName`| The `curity.config.configurationSecret`'s item name, required if the Secret is set. |`null`
 `curity.config.configurationConfigMap`| The ConfigMap containing configuration which is mounted as a volume  |`null`
-`curity.config.configurationConfigMapItemNames`| Array of The `curity.config.configurationConfigMap`'s item names, required if the ConfigMap is set. |`null`
+`curity.config.configurationConfigMapItemName`| The `curity.config.configurationConfigMap`'s item name, required if the ConfigMap is set. |`null`
+`curity.config.configurationExtraConfigMap`| The ConfigMap containing configuration which is mounted as a volume  |`null`
+`curity.config.configurationExtraConfigMapItemNames`| Array of the `curity.config.configurationExtraConfigMap`'s item names, required if the ExtraConfigMap is set. |`null`
 `curity.config.backup` | If `true`, the configuration will be backed up in a secret in each commit | `false` 
 `ingress.enabled`| Flag to enable/disable an Ingress resource |`false`
 `ingress.annotations`| Extra annotations for the Ingress resource   |`{}`

--- a/idsvr/README.md
+++ b/idsvr/README.md
@@ -96,7 +96,7 @@ Parameter | Description | Default
 `curity.config.configurationSecret`| The Secret containing configuration which is mounted as a volume  |`null`
 `curity.config.configurationSecretItemName`| The `curity.config.configurationSecret`'s item name, required if the Secret is set. |`null`
 `curity.config.configurationConfigMap`| The ConfigMap containing configuration which is mounted as a volume  |`null`
-`curity.config.configurationConfigMapItemNames`| List of The `curity.config.configurationConfigMap`'s item names, required if the ConfigMap is set. |`null`
+`curity.config.configurationConfigMapItemNames`| Array of The `curity.config.configurationConfigMap`'s item names, required if the ConfigMap is set. |`null`
 `curity.config.backup` | If `true`, the configuration will be backed up in a secret in each commit | `false` 
 `ingress.enabled`| Flag to enable/disable an Ingress resource |`false`
 `ingress.annotations`| Extra annotations for the Ingress resource   |`{}`

--- a/idsvr/README.md
+++ b/idsvr/README.md
@@ -96,7 +96,7 @@ Parameter | Description | Default
 `curity.config.configurationSecret`| The Secret containing configuration which is mounted as a volume  |`null`
 `curity.config.configurationSecretItemName`| The `curity.config.configurationSecret`'s item name, required if the Secret is set. |`null`
 `curity.config.configurationConfigMap`| The ConfigMap containing configuration which is mounted as a volume  |`null`
-`curity.config.configurationConfigMapItemName`| The `curity.config.configurationConfigMap`'s item name, required if the ConfigMap is set. |`null`
+`curity.config.configurationConfigMapItemNames`| List of The `curity.config.configurationConfigMap`'s item names, required if the ConfigMap is set. |`null`
 `curity.config.backup` | If `true`, the configuration will be backed up in a secret in each commit | `false` 
 `ingress.enabled`| Flag to enable/disable an Ingress resource |`false`
 `ingress.annotations`| Extra annotations for the Ingress resource   |`{}`

--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -114,12 +114,10 @@ spec:
             {{- end }}
             {{- if .Values.curity.config.configurationConfigMap }}
             {{- range $item := required "\n curity.config.configurationConfigMapItemNames required when curity.config.configurationConfigMap is set. " .Values.curity.config.configurationConfigMapItemNames}}
-            {{- range $file := $item.files }}
-            - mountPath: /opt/idsvr/{{ $item.path }}/{{ $file }}
-              subPath: {{ $file }}
+            - mountPath: /opt/idsvr/etc/init/{{ $item }}
+              subPath: {{ $item }}
               name: config-volume
               readOnly: true
-            {{- end }}
             {{- end }}
             {{- end }}
           resources:

--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -113,10 +113,14 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.curity.config.configurationConfigMap }}
-            - mountPath: /opt/idsvr/etc/init/configmap-config.xml
-              subPath: {{ required "\n curity.config.configurationConfigMapItemName required when curity.config.configurationConfigMap is set. " .Values.curity.config.configurationConfigMapItemName }}
-              name: configmap-config
+            {{- range $item := required "\n curity.config.configurationConfigMapItemNames required when curity.config.configurationConfigMap is set. " .Values.curity.config.configurationConfigMapItemNames}}
+            {{- range $file := $item.files }}
+            - mountPath: /opt/idsvr/{{ $item.path }}/{{ $file }}
+              subPath: {{ $file }}
+              name: config-volume
               readOnly: true
+            {{- end }}
+            {{- end }}
             {{- end }}
           resources:
                 {{- toYaml .Values.resources | nindent 12 }}
@@ -167,7 +171,7 @@ spec:
                 path: backupConfig.sh
         {{- end -}}
         {{- if .Values.curity.config.configurationConfigMap }}
-        - name: configmap-config
+        - name: config-volume
           configMap:
             name: {{ .Values.curity.config.configurationConfigMap }}
         {{- end }}

--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -113,10 +113,16 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.curity.config.configurationConfigMap }}
-            {{- range $item := required "\n curity.config.configurationConfigMapItemNames required when curity.config.configurationConfigMap is set. " .Values.curity.config.configurationConfigMapItemNames}}
+            - mountPath: /opt/idsvr/etc/init/configmap-config.xml
+              subPath: {{ required "\n curity.config.configurationConfigMapItemName required when curity.config.configurationConfigMap is set. " .Values.curity.config.configurationConfigMapItemName }}
+              name: configmap-config
+              readOnly: true
+            {{- end }}
+            {{- if .Values.curity.config.configurationExtraConfigMap }}
+            {{- range $item := required "\n curity.config.configurationExtraConfigMapItemNames required when curity.config.configurationExtraConfigMap is set. " .Values.curity.config.configurationExtraConfigMapItemNames}}
             - mountPath: /opt/idsvr/etc/init/{{ $item }}
               subPath: {{ $item }}
-              name: config-volume
+              name: config-extra-volume
               readOnly: true
             {{- end }}
             {{- end }}
@@ -169,9 +175,14 @@ spec:
                 path: backupConfig.sh
         {{- end -}}
         {{- if .Values.curity.config.configurationConfigMap }}
-        - name: config-volume
+        - name: configmap-config
           configMap:
             name: {{ .Values.curity.config.configurationConfigMap }}
+        {{- end }}
+        {{- if .Values.curity.config.configurationExtraConfigMap }}
+        - name: config-extra-volume
+          configMap:
+            name: {{ .Values.curity.config.configurationExtraConfigMap }}
         {{- end }}
       {{- if .Values.curity.config.backup }}
       serviceAccountName: {{ include "curity.fullname" . }}-service-account

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -89,7 +89,7 @@ spec:
             {{- end }}
             {{- if .Values.curity.config.configurationConfigMap }}
             {{- range $item := required "\n curity.config.configurationConfigMapItemNames required when curity.config.configurationConfigMap is set. " .Values.curity.config.configurationConfigMapItemNames }}
-            {{- range $file := $item }}
+            {{- range $file := $item.files }}
             - mountPath: /opt/idsvr/{{ $item.path }}/{{ $file }}
               subPath: {{ $file }}
               name: config-volume

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -89,12 +89,10 @@ spec:
             {{- end }}
             {{- if .Values.curity.config.configurationConfigMap }}
             {{- range $item := required "\n curity.config.configurationConfigMapItemNames required when curity.config.configurationConfigMap is set. " .Values.curity.config.configurationConfigMapItemNames }}
-            {{- range $file := $item.files }}
-            - mountPath: /opt/idsvr/{{ $item.path }}/{{ $file }}
-              subPath: {{ $file }}
+            - mountPath: /opt/idsvr/etc/init/{{ $item }}
+              subPath: {{ $item }}
               name: config-volume
               readOnly: true
-            {{- end }}
             {{- end }}
             {{- end }}
           resources:

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -88,10 +88,16 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.curity.config.configurationConfigMap }}
-            {{- range $item := required "\n curity.config.configurationConfigMapItemNames required when curity.config.configurationConfigMap is set. " .Values.curity.config.configurationConfigMapItemNames }}
+            - mountPath: /opt/idsvr/etc/init/configmap-config.xml
+              subPath: {{ required "\n curity.config.configurationConfigMapItemName required when curity.config.configurationConfigMap is set. " .Values.curity.config.configurationConfigMapItemName }}
+              name: configmap-config
+              readOnly: true
+            {{- end }}
+            {{- if .Values.curity.config.configurationExtraConfigMap }}
+            {{- range $item := required "\n curity.config.configurationExtraConfigMapItemNames required when curity.config.configurationExtraConfigMap is set. " .Values.curity.config.configurationExtraConfigMapItemNames }}
             - mountPath: /opt/idsvr/etc/init/{{ $item }}
               subPath: {{ $item }}
-              name: config-volume
+              name: config-extra-volume
               readOnly: true
             {{- end }}
             {{- end }}
@@ -135,9 +141,14 @@ spec:
                 path: config.xml
         {{- end }}
         {{- if .Values.curity.config.configurationConfigMap }}
-        - name: config-volume
+        - name: configmap-config
           configMap:
             name: {{ .Values.curity.config.configurationConfigMap }}
+        {{- end }}
+        {{- if .Values.curity.config.configurationExtraConfigMap }}
+        - name: config-extra-volume
+          configMap:
+            name: {{ .Values.curity.config.configurationExtraConfigMap }}
         {{- end }}
             {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -88,10 +88,14 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.curity.config.configurationConfigMap }}
-            - mountPath: /opt/idsvr/etc/init/configmap-config.xml
-              subPath: {{ required "\n curity.config.configurationConfigMapItemName required when curity.config.configurationConfigMap is set. " .Values.curity.config.configurationConfigMapItemName }}
-              name: configmap-config
+            {{- range $item := required "\n curity.config.configurationConfigMapItemNames required when curity.config.configurationConfigMap is set. " .Values.curity.config.configurationConfigMapItemNames }}
+            {{- range $file := $item }}
+            - mountPath: /opt/idsvr/{{ $item.path }}/{{ $file }}
+              subPath: {{ $file }}
+              name: config-volume
               readOnly: true
+            {{- end }}
+            {{- end }}
             {{- end }}
           resources:
                 {{- toYaml .Values.resources | nindent 12 }}
@@ -133,7 +137,7 @@ spec:
                 path: config.xml
         {{- end }}
         {{- if .Values.curity.config.configurationConfigMap }}
-        - name: configmap-config
+        - name: config-volume
           configMap:
             name: {{ .Values.curity.config.configurationConfigMap }}
         {{- end }}

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -97,7 +97,7 @@ curity:
     encryptionKey:
     environmentVariableSecret:
     configurationConfigMap:
-    configurationConfigMapItemName:
+    configurationConfigMapItemNames:
     configurationSecret:
     configurationSecretItemName:
 

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -97,7 +97,9 @@ curity:
     encryptionKey:
     environmentVariableSecret:
     configurationConfigMap:
-    configurationConfigMapItemNames:
+    configurationConfigMapItemName:
+    configurationExtraConfigMap:
+    configurationExtraConfigMapItemNames:
     configurationSecret:
     configurationSecretItemName:
 


### PR DESCRIPTION
Configuration in Curity might be done using many xml-files. By adding a configurationExtraConfigMap that support many items it is possible to configure the server using more than one file. All files specified will be mounted in etc/init folder in the container. 
In the `helm-values.yaml` file:
```    
configurationExtraConfigMap: extra-configmap-conf  
configurationExtraConfigMapItemNames:
        - admin-user.xml
        - authentication.xml
        - base.xml
        - environment.xml
        - facilties.xm
        - oauth.xml
        - user-managment.xml
```
