### PR TITLE
Support valueFrom in extraEnv params

### DIFF
--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -50,9 +50,16 @@ spec:
             - name: SECRET_NAME
               value: {{ include "curity.fullname" . }}-config-backup
           {{- end }}
-          {{- if .Values.curity.admin.extraEnv }}
-{{ toYaml .Values.curity.admin.extraEnv | indent 12 }}
-          {{- end }}
+          {{- range $env := .Values.curity.admin.extraEnv }}
+            - name: {{ $env.name }}
+            {{- if $env.value }}
+              value: {{ $env.value | quote }}
+            {{- end }}
+            {{- if $env.valueFrom }}
+              valueFrom: 
+{{ $env.valueFrom | toYaml | trim | indent 16 }}
+            {{- end }}
+          {{- end}}
           {{- if ( or .Values.curity.config.environmentVariableSecret .Values.curity.config.environmentVariableConfigMap ) }}
           envFrom:
           {{- if .Values.curity.config.environmentVariableConfigMap }}

--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -50,9 +50,8 @@ spec:
             - name: SECRET_NAME
               value: {{ include "curity.fullname" . }}-config-backup
           {{- end }}
-          {{- range $env := .Values.curity.admin.extraEnv }}
-            - name: {{ $env.name }}
-              value: {{ $env.value | quote }}
+          {{- if .Values.curity.admin.extraEnv }}
+{{ toYaml .Values.curity.admin.extraEnv | indent 12 }}
           {{- end }}
           {{- if ( or .Values.curity.config.environmentVariableSecret .Values.curity.config.environmentVariableConfigMap ) }}
           envFrom:

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -36,9 +36,15 @@ spec:
               value: {{ .Values.curity.healthCheckPort | quote }}
             - name: LOGGING_LEVEL
               value: {{ .Values.curity.runtime.logging.level }}
-            {{- if .Values.curity.runtime.extraEnv }}
-{{ toYaml .Values.curity.runtime.extraEnv | indent 12 }}
-            {{- end }}
+            {{- range $env := .Values.curity.admin.extraEnv }}
+            - name: {{ $env.name }}
+              {{- if $env.value }}
+              value: {{ $env.value | quote }}
+              {{- end }}
+              {{- if $env.valueFrom }}
+              valueFrom: 
+{{ $env.valueFrom | toYaml | trim | indent 16 }}
+              {{- end }}
           {{- if ( or .Values.curity.config.environmentVariableSecret .Values.curity.config.environmentVariableConfigMap ) }}
           envFrom:
           {{- if .Values.curity.config.environmentVariableConfigMap }}

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -36,9 +36,8 @@ spec:
               value: {{ .Values.curity.healthCheckPort | quote }}
             - name: LOGGING_LEVEL
               value: {{ .Values.curity.runtime.logging.level }}
-            {{- range $env := .Values.curity.runtime.extraEnv }}
-            - name: {{ $env.name }}
-              value: {{ $env.value | quote }}
+            {{- if .Values.curity.runtime.extraEnv }}
+{{ toYaml .Values.curity.runtime.extraEnv | indent 12 }}
             {{- end }}
           {{- if ( or .Values.curity.config.environmentVariableSecret .Values.curity.config.environmentVariableConfigMap ) }}
           envFrom:

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -36,7 +36,7 @@ spec:
               value: {{ .Values.curity.healthCheckPort | quote }}
             - name: LOGGING_LEVEL
               value: {{ .Values.curity.runtime.logging.level }}
-            {{- range $env := .Values.curity.admin.extraEnv }}
+            {{- range $env := .Values.curity.runtime.extraEnv }}
             - name: {{ $env.name }}
               {{- if $env.value }}
               value: {{ $env.value | quote }}
@@ -45,6 +45,7 @@ spec:
               valueFrom: 
 {{ $env.valueFrom | toYaml | trim | indent 16 }}
               {{- end }}
+            {{- end }}
           {{- if ( or .Values.curity.config.environmentVariableSecret .Values.curity.config.environmentVariableConfigMap ) }}
           envFrom:
           {{- if .Values.curity.config.environmentVariableConfigMap }}


### PR DESCRIPTION
- Adds support for `extraEnv` parameters

Example configuration:
```
curity:
  admin:
    extraEnv:
      - name: AGENT_HOST
        valueFrom:
          fieldRef:
            fieldPath: status.hostIP

  runtime:
    extraEnv:
      - name: AGENT_HOST
        valueFrom:
          fieldRef:
            fieldPath: status.hostIP
```