### PR TITLE
Fix newline issue for $env.valueFrom

### DIFF
--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -56,8 +56,7 @@ spec:
               value: {{ $env.value | quote }}
             {{- end }}
             {{- if $env.valueFrom }}
-              valueFrom: 
-                {{- $env.valueFrom | toYaml | trim | indent 16 }}
+              valueFrom: {{ $env.valueFrom | toYaml | trim | nindent 16 }}
             {{- end }}
           {{- end}}
           {{- if ( or .Values.curity.config.environmentVariableSecret .Values.curity.config.environmentVariableConfigMap .Values.curity.config.environmentVariableSecrets .Values.curity.config.environmentVariableConfigMaps ) }}

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -42,8 +42,7 @@ spec:
               value: {{ $env.value | quote }}
               {{- end }}
               {{- if $env.valueFrom }}
-              valueFrom: 
-                {{- $env.valueFrom | toYaml | trim | indent 16 }}
+              valueFrom: {{ $env.valueFrom | toYaml | trim | nindent 16 }}
               {{- end }}
             {{- end }}
           {{- if ( or .Values.curity.config.environmentVariableSecret .Values.curity.config.environmentVariableConfigMap .Values.curity.config.environmentVariableSecrets .Values.curity.config.environmentVariableConfigMaps ) }}


### PR DESCRIPTION
Currently, the template will render as
```
            - name: DD_AGENT_HOST
              valueFrom:                fieldRef:
                  fieldPath: status.hostIP
```

which will cause an error:

```
Error: YAML parse error on idsvr/templates/deployment-runtime.yaml: error converting YAML to JSON: yaml: line 43: mapping values are not allowed in this context
```

This fixes the rendering issue by using `nindent`