### PR TITLE
Allow configuration of custom ServiceAccount for runtime nodes

### DIFF
--- a/idsvr/README.md
+++ b/idsvr/README.md
@@ -75,6 +75,7 @@ Parameter | Description | Default
 `curity.runtime.role`| The role of the runtime servers | `default`
 `curity.runtime.service.type`| The runtime service type | `ClusterIP`
 `curity.runtime.service.port`| The runtime service port | `8443`
+`curity.runtime.serviceAccount.name`| The name of an existing service account to use on the runtime nodes. Defaults to `default` if not specified.  | `null`
 `curity.runtime.deployment.port`| The runtime deployment port | `8443`
 `curity.runtime.extraEnv`| Extra environment variables to provide to the runtime container | `[]`
 `curity.runtime.livenessProbe.timeoutSeconds`| LivenessProbe `timeoutSeconds` for the runtime deployment | `1`

--- a/idsvr/templates/_helpers.tpl
+++ b/idsvr/templates/_helpers.tpl
@@ -41,3 +41,10 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- define "curity.metricsPort" -}}
 {{ add .Values.curity.healthCheckPort  1 }}
 {{- end -}}
+
+{{/*
+Creates the name of the service account used by the runtime nodes.
+*/}}
+{{- define "curity.runtime.serviceAccountName" -}}
+  {{ default "default" .Values.curity.runtime.serviceAccount.name }}
+{{- end -}}

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -192,6 +192,7 @@ spec:
               {{- end }}
         {{- end }}
         {{- end }}
+      serviceAccountName: {{ template "curity.runtime.serviceAccountName" . }}
             {{- with .Values.nodeSelector }}
       nodeSelector:
             {{- toYaml . | nindent 8 }}

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -66,6 +66,8 @@ curity:
       type: ClusterIP
       port: 8443
       annotations: {}
+    serviceAccount:
+      name:
     deployment:
       port: 8443
     livenessProbe:


### PR DESCRIPTION
The purpose of this PR is to allow setting a custom `ServiceAccount` on the runtime nodes only. Defaults to `default` if not set which is the current behaviour.

Creating a new `ServiceAccount` is outside the scope. It assumes it has already been created by some external process.