### PR TITLE
Use the v2beta2 syntax for CPU and Memory autoscaling

### DIFF
--- a/idsvr/Chart.yaml
+++ b/idsvr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: idsvr
-version: 0.11.5
+version: 0.11.6
 appVersion: 7.4.2
 description: A Helm chart for Curity Identity Server
 keywords:

--- a/idsvr/templates/hpa.yaml
+++ b/idsvr/templates/hpa.yaml
@@ -20,12 +20,16 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
   {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
   - type: Resource
     resource:
       name: memory
-      targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
I made a small change so that the syntax output for the HPA is now correct for v2beta2 for CPU and memory:

```yaml
metrics:
- type: Resource
  resource:
    name: cpu
    target:
      type: Utilization
      averageUtilization: 80
```
Customers then need to install the metrics-server, which could be done like this in a basic development install:

```bash
kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml --kubelet-insecure-tls
```
By default I then get [this issue](https://github.com/kubernetes-sigs/metrics-server/blob/master/KNOWN_ISSUES.md#hpa-is-unable-to-get-resource-utilization), and from googling it seems that [resource limits should also be activated for this feature to work](https://docs.openshift.com/container-platform/4.10/nodes/pods/nodes-pods-autoscaling.html#nodes-pods-autoscaling-requests-and-limits-hpa_nodes-pods-autoscaling). Eg also set this in the Helm chart:

```yaml
resources:
  limits:
    cpu: 500m
  requests:
    cpu: 500m
```

For now I will add some brief notes to the autoscaling tutorial to indicate that `you may also need to set CPU / memory resource limits`. This behaviour could change in future I think.