### PR TITLE
Mount var on an ephemeral volume to support a readOnlyRootFilesystem

### DIFF
--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -120,6 +120,8 @@ spec:
             periodSeconds: {{ .Values.curity.admin.readinessProbe.periodSeconds }}
             initialDelaySeconds: {{ .Values.curity.admin.readinessProbe.initialDelaySeconds }}
           volumeMounts:
+            - mountPath: /opt/idsvr/var
+              name: var-volume
             {{- if .Values.curity.admin.logging.stdout }}
             - mountPath: /opt/idsvr/var/log/
               name: log-volume
@@ -189,6 +191,8 @@ spec:
         - name: {{ .Values.image.pullSecret}}
       {{- end }}
       volumes:
+        - name: var-volume
+          emptyDir: {}
         {{- if .Values.curity.admin.logging.stdout }}
         - name: log-volume
           emptyDir: {}
@@ -246,8 +250,20 @@ spec:
       {{- if .Values.curity.config.backup }}
       serviceAccountName: {{ include "curity.fullname" . }}-service-account
       {{- end }}
-      {{- with .Values.curity.admin.initContainers }}
       initContainers:
+        - name: populate-var
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command:
+            - cp
+            - '--no-dereference'
+            - '--preserve=links'
+            - '--recursive'
+            - /opt/idsvr/var/.
+            - /tmp/var
+          volumeMounts:
+            - mountPath: /tmp/var
+              name: var-volume
+      {{- with .Values.curity.admin.initContainers }}
             {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -100,6 +100,8 @@ spec:
             periodSeconds: {{ .Values.curity.runtime.readinessProbe.periodSeconds }}
             initialDelaySeconds: {{ .Values.curity.runtime.readinessProbe.initialDelaySeconds }}
           volumeMounts:
+            - mountPath: /opt/idsvr/var
+              name: var-volume
             {{- if .Values.curity.runtime.logging.stdout }}
             - mountPath: /opt/idsvr/var/log/
               name: log-volume
@@ -159,6 +161,8 @@ spec:
         - name: {{ .Values.image.pullSecret}}
       {{- end }}
       volumes:
+        - name: var-volume
+          emptyDir: {}
         {{- if .Values.curity.runtime.logging.stdout }}
         - name: log-volume
           emptyDir: {}
@@ -205,8 +209,20 @@ spec:
         {{- end }}
         {{- end }}
       serviceAccountName: {{ template "curity.runtime.serviceAccountName" . }}
-      {{- with .Values.curity.runtime.initContainers }}
       initContainers:
+        - name: populate-var
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command:
+            - cp
+            - '--no-dereference'
+            - '--preserve=links'
+            - '--recursive'
+            - /opt/idsvr/var/.
+            - /tmp/var
+          volumeMounts:
+            - mountPath: /tmp/var
+              name: var-volume
+      {{- with .Values.curity.runtime.initContainers }}
             {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
Our company policy encourages product teams to set `readOnlyRootFilesystem: true` on our pods' `securityContext`. That's possible if all the write activity in the `/opt/idsvr/var` directory is done on an ephemeral volume. Is Curity interested in making this a standard feature in the Helm chart?