### PR TITLE
[feature] Ingress per component

### DIFF
--- a/idsvr/templates/ingress.yaml
+++ b/idsvr/templates/ingress.yaml
@@ -10,16 +10,11 @@ metadata:
         {{- toYaml . | nindent 4 }}
         {{- end }}
 spec:
-{{- if or .Values.ingress.admin.secretName .Values.ingress.runtime.secretName }}
+{{- if .Values.ingress.runtime.secretName }}
   tls:
-    {{- if .Values.ingress.admin.secretName }}
-    - hosts:
-        - {{ .Values.ingress.admin.host}}
-      secretName: {{ .Values.ingress.admin.secretName }}
-    {{- end }}
     {{- if .Values.ingress.runtime.secretName }}
     - hosts:
-        - {{ .Values.ingress.runtime.host}}
+        - {{ .Values.ingress.runtime.host }}
       secretName: {{ .Values.ingress.runtime.secretName }}
     {{- end }}
 {{- end }}
@@ -36,7 +31,28 @@ spec:
                 port:
                   name: http-port
           {{- end }}
-  {{- if .Values.curity.config.uiEnabled }}
+{{- if .Values.curity.config.uiEnabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "curity.fullname" . }}-ingress-admin
+  labels:
+        {{- include "curity.labels" . | nindent 4 }}
+        {{- with .Values.ingress.annotations }}
+  annotations:
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
+spec:
+{{- if .Values.ingress.admin.secretName }}
+  tls:
+    {{- if .Values.ingress.admin.secretName }}
+    - hosts:
+        - {{ .Values.ingress.admin.host}}
+      secretName: {{ .Values.ingress.admin.secretName }}
+    {{- end }}
+{{- end }}
+  rules:
     - host: {{ .Values.ingress.admin.host }}
       http:
         paths:
@@ -47,5 +63,5 @@ spec:
                 name: {{ include "curity.fullname" . }}-admin-svc
                 port:
                   name: admin-ui
-  {{- end }}
+{{- end }}
 {{- end }}

--- a/idsvr/templates/ingress.yaml
+++ b/idsvr/templates/ingress.yaml
@@ -5,10 +5,18 @@ metadata:
   name: {{ include "curity.fullname" . }}-ingress
   labels:
         {{- include "curity.labels" . | nindent 4 }}
-        {{- with .Values.ingress.annotations }}
+    {{- if or .Values.ingress.runtime.annotations .Values.ingress.annotations }}
   annotations:
+      {{- if .Values.ingress.runtime.annotations }}
+        {{- with .Values.ingress.runtime.annotations }}
         {{- toYaml . | nindent 4 }}
         {{- end }}
+      {{- else }}
+        {{- with .Values.ingress.annotations }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
 spec:
 {{- if .Values.ingress.runtime.secretName }}
   tls:
@@ -43,10 +51,18 @@ metadata:
   name: {{ include "curity.fullname" . }}-ingress-admin
   labels:
         {{- include "curity.labels" . | nindent 4 }}
-        {{- with .Values.ingress.annotations }}
+    {{- if or .Values.ingress.admin.annotations .Values.ingress.annotations }}
   annotations:
+      {{- if .Values.ingress.admin.annotations }}
+        {{- with .Values.ingress.admin.annotations }}
         {{- toYaml . | nindent 4 }}
         {{- end }}
+      {{- else }}
+        {{- with .Values.ingress.annotations }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
 spec:
 {{- if .Values.ingress.admin.secretName }}
   tls:

--- a/idsvr/templates/ingress.yaml
+++ b/idsvr/templates/ingress.yaml
@@ -14,7 +14,11 @@ spec:
   tls:
     {{- if .Values.ingress.runtime.secretName }}
     - hosts:
+      {{- if .Values.ingress.runtime.tlsHost }}
+        - {{ .Values.ingress.runtime.tlsHost | quote }}
+      {{- else }}
         - {{ .Values.ingress.runtime.host }}
+      {{- end }}
       secretName: {{ .Values.ingress.runtime.secretName }}
     {{- end }}
 {{- end }}
@@ -48,7 +52,11 @@ spec:
   tls:
     {{- if .Values.ingress.admin.secretName }}
     - hosts:
+      {{- if .Values.ingress.admin.tlsHost }}
+        - {{ .Values.ingress.admin.tlsHost | quote }}
+      {{- else }}
         - {{ .Values.ingress.admin.host}}
+      {{- end }}
       secretName: {{ .Values.ingress.admin.secretName }}
     {{- end }}
 {{- end }}

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -164,9 +164,11 @@ ingress:
     secretName:
     paths:
       - /
+    # annotations: {}
   admin:
     host: curity-admin.local
     secretName:
+    # annotations: {}
 
 resources: {}
 # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## Descrription

This PR split the current ingress into 2 ingresses, 1 per component.
So we gain finer control.
For example we can use different annotations, so use different ingress class if we want to expose runtime into a public subnet and admin into a private subnet.

I also add a dedicated value for tls host, as we may want to use wildcard as host; on big kubernetes it reduces the risk of rate limit to _let's encrypt._
