### PR TITLE
[feature] Offer egress network policy to databases

### DIFF
--- a/idsvr/templates/network.yaml
+++ b/idsvr/templates/network.yaml
@@ -9,9 +9,6 @@ spec:
       role: {{ include "curity.fullname" . }}-admin
   policyTypes:
     - Ingress
-  {{- if .Values.networkpolicy.database.enabled }}
-    - Egress
-  {{- end }}
   ingress:
     - from:
         - podSelector:
@@ -20,19 +17,6 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.curity.admin.service.port }}
-  {{- if .Values.networkpolicy.database.enabled }}
-  egress:
-    - to
-    {{- range .Values.networkpolicy.database.cidr }}
-      - ipBlock:
-          cidr: {{ . }}
-    {{- end }}
-    {{- range .Values.networkpolicy.database.ports }}
-      ports:
-        - protocol: TCP
-          port: {{ . }}
-    {{- end }}
-  {{- end }}
 {{- if .Values.networkpolicy.database.enabled }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/idsvr/templates/network.yaml
+++ b/idsvr/templates/network.yaml
@@ -9,7 +9,7 @@ spec:
       role: {{ include "curity.fullname" . }}-admin
   policyTypes:
     - Ingress
-  {{- if .Values.networkpolicy.postgresql.enabled }}
+  {{- if .Values.networkpolicy.database.enabled }}
     - Egress
   {{- end }}
   ingress:
@@ -20,18 +20,20 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.curity.admin.service.port }}
-  {{- if .Values.networkpolicy.postgresql.enabled }}
+  {{- if .Values.networkpolicy.database.enabled }}
   egress:
     - to
-    {{- range .Values.networkpolicy.postgresql.cidr }}
+    {{- range .Values.networkpolicy.database.cidr }}
       - ipBlock:
           cidr: {{ . }}
     {{- end }}
+    {{- range .Values.networkpolicy.database.ports }}
       ports:
         - protocol: TCP
-          port: 5432
+          port: {{ . }}
+    {{- end }}
   {{- end }}
-{{- if .Values.networkpolicy.postgresql.enabled }}
+{{- if .Values.networkpolicy.database.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -45,12 +47,14 @@ spec:
     - Egress
   egress:
     - to:
-    {{- range .Values.networkpolicy.postgresql.cidr }}
+    {{- range .Values.networkpolicy.database.cidr }}
       - ipBlock:
           cidr: {{ . }}
     {{- end }}
+    {{- range .Values.networkpolicy.database.ports }}
       ports:
         - protocol: TCP
-          port: 5432
+          port: {{ . }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/idsvr/templates/network.yaml
+++ b/idsvr/templates/network.yaml
@@ -9,6 +9,9 @@ spec:
       role: {{ include "curity.fullname" . }}-admin
   policyTypes:
     - Ingress
+  {{- if .Values.networkpolicy.postgresql.enabled }}
+    - Egress
+  {{- end }}
   ingress:
     - from:
         - podSelector:
@@ -17,4 +20,37 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.curity.admin.service.port }}
+  {{- if .Values.networkpolicy.postgresql.enabled }}
+  egress:
+    - to
+    {{- range .Values.networkpolicy.postgresql.cidr }}
+      - ipBlock:
+          cidr: {{ . }}
+    {{- end }}
+      ports:
+        - protocol: TCP
+          port: 5432
+  {{- end }}
+{{- if .Values.networkpolicy.postgresql.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "curity.fullname" . }}-network-policy-runtime
+spec:
+  podSelector:
+    matchLabels:
+      role: {{ include "curity.fullname" . }}-runtime
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+    {{- range .Values.networkpolicy.postgresql.cidr }}
+      - ipBlock:
+          cidr: {{ . }}
+    {{- end }}
+      ports:
+        - protocol: TCP
+          port: 5432
+{{- end }}
 {{- end }}

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -15,8 +15,9 @@ fullnameOverride: ""
 labels: {}
 networkpolicy:
   enabled: true
-  postgresql:
+  database:
     enabled: false
+    ports: []
     cidr: []
 
 curity:

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -15,6 +15,9 @@ fullnameOverride: ""
 labels: {}
 networkpolicy:
   enabled: true
+  postgresql:
+    enabled: false
+    cidr: []
 
 curity:
   healthCheckPort: 4465


### PR DESCRIPTION
## Description

Add postgresql netpol egress in case we use netpol and postgresql as database

## Reference

https://curity.io/docs/idsvr/latest/system-admin-guide/data-sources/jdbc.html#postgresql-and-cockroachdb