### PR TITLE
[feature] We should be able to define resources for logging containers

### DIFF
--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -191,6 +191,8 @@ spec:
             - name: log-volume
               mountPath: /log
               readOnly: true
+          resources:
+                {{- toYaml $root.Values.logging.resources | nindent 12 }}
         {{- end }}
         {{- end }}
       {{- if .Values.image.pullSecret }}

--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -161,6 +161,8 @@ spec:
             - name: log-volume
               mountPath: /log
               readOnly: true
+          resources:
+                {{- toYaml $root.Values.logging.resources | nindent 12 }}
         {{- end }}
         {{- end }}
       {{- if .Values.image.pullSecret }}

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -168,6 +168,9 @@ ingress:
     host: curity-admin.local
     secretName:
 
+logging:
+  resources: {}
+
 resources: {}
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## Description

The current chart offers resources definitions for _runtime_ and _admin_ containers, it should also be offered for _logging_ containers.