### PR TITLE
Invalid context inside range

### DIFF
--- a/idsvr/templates/ingress.yaml
+++ b/idsvr/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
         paths:
           {{- range .Values.ingress.runtime.paths }}
           - path: {{ . }}
-            pathType: {{ .Values.ingress.runtime.pathType }}
+            pathType: {{ $.Values.ingress.runtime.pathType }}
             backend:
               service:
                 name: {{ include "curity.fullname" $ }}-runtime-svc


### PR DESCRIPTION
Inside a range block `.` refers to the current value, and `$` should be used to refer to the root.

The current code results in the error:
```
  Error: UPGRADE FAILED: template: idsvr/templates/ingress.yaml:38:32: executing "idsvr/templates/ingress.yaml" at <.Values.ingress.runtime.pathType>: can't evaluate field Values in type interface {}
```