### PR TITLE
Include image pull policy to support latest tag

### DIFF
--- a/idsvr/Chart.yaml
+++ b/idsvr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: idsvr
-version: 0.12.0
+version: 0.12.1
 appVersion: 8.0.0
 description: A Helm chart for Curity Identity Server
 keywords:

--- a/idsvr/templates/cluster-conf.yaml
+++ b/idsvr/templates/cluster-conf.yaml
@@ -59,6 +59,7 @@ spec:
       containers:
         - name: {{ include "curity.fullname" . }}-cluster-conf-job
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["sh",  "/opt/idsvr/bin/createConfigSecret.sh"]
           env:
             - name: CONFIG_SERVICE_HOST

--- a/idsvr/templates/convertKeystore-conf.yaml
+++ b/idsvr/templates/convertKeystore-conf.yaml
@@ -62,6 +62,7 @@ spec:
       containers:
         - name: {{ $convertKs.sourceTls.keyName | lower | replace "_" "-" }}-keystore-conf-job
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: [ "sh", "/opt/idsvr/bin/convertKeystoreSecret.sh" ]
           env:
             - name: SECRET_NAME


### PR DESCRIPTION
In some development examples, a custom Docker image is pulled into a KIND registry, and will not be found otherwise:

```bash
kind load docker-image custom_idsvr:latest --name curity
```

The `latest` tag provides best future proofing of examples.\
Yet there is a [special rule](https://spacelift.io/blog/kubernetes-imagepullpolicy) which means the installation fails for the `cluster-conf` image:

```text
If the image tag is :latest, the imagePullPolicy will be automatically set to `Always`.
```

This change applies the value from the Helm chart to all instances of the `curity/idsvr` image.\
This expresses the installing user's intent, and defaults to `IfNotPresent` if not set.\
This fixes the KIND issue and will have no adverse impact on other scenarios.