### PR TITLE
Allow the admin deployment to be disabled

### DIFF
--- a/idsvr/README.md
+++ b/idsvr/README.md
@@ -60,6 +60,7 @@ In the table below you can find information about the parameters that are config
 | `curity.healthCheckPort` | The port to use for the status server| `4465` |
 | `curity.adminUiPort` | The admin UI and API port. Ignored if `curity.config.uiEnabled=false` and `ingress.admin.enabled=false` | `6749` |
 | `curity.adminUiHttp` | Controls if admin UI will be on http or https mode after installation if enabled. Ignored if `curity.config.uiEnabled=false` | `false` |
+| `curity.admin.enabled` | Whether to have an admin deployment | `{}` |
 | `curity.admin.annotations` | Extra annotations to add to the admin deployment | `{}` |
 | `curity.admin.podLabels` | Extra labels to add to the admin pod | `{}` |
 | `curity.admin.podAnnotations` | Extra annotations to add to the admin pod | `{}` |

--- a/idsvr/templates/deployment-admin.yaml
+++ b/idsvr/templates/deployment-admin.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.curity.admin.enabled }}
 {{- $root := . -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -103,7 +104,7 @@ spec:
             - name: metrics
               containerPort: {{ include "curity.metricsPort" . }}
               protocol: TCP
-          {{- if or .Values.curity.config.uiEnabled .Values.ingress.admin.enabled }}
+          {{- if or .Values.curity.config.uiEnabled (and .Values.ingress.admin.enabled .Values.ingress.admin.enabled) }}
             - name: admin-ui
               containerPort: {{ .Values.curity.adminUiPort }}
               protocol: TCP
@@ -280,3 +281,4 @@ spec:
       tolerations:
             {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/idsvr/templates/ingress.yaml
+++ b/idsvr/templates/ingress.yaml
@@ -40,7 +40,7 @@ spec:
                   name: http-port
           {{- end }}
 {{- end }}
-{{- if .Values.ingress.admin.enabled }}
+{{- if and .Values.curity.admin.enabled .Values.ingress.admin.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/idsvr/templates/service-admin.yaml
+++ b/idsvr/templates/service-admin.yaml
@@ -24,7 +24,7 @@ spec:
       targetPort: metrics
       protocol: TCP
       name: metrics
-    {{- if or .Values.curity.config.uiEnabled .Values.ingress.admin.enabled }}
+    {{- if or .Values.curity.config.uiEnabled (and .Values.curity.admin.enabled .Values.ingress.admin.enabled) }}
     - port: {{ .Values.curity.adminUiPort }}
       targetPort: admin-ui
       protocol: TCP

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -22,6 +22,7 @@ curity:
   adminUiHttp: false
 
   admin:
+    enabled: true
     role: admin
     annotations: {}
     podLabels: {}


### PR DESCRIPTION
Since the runtime doesn't require the admin deployment, the chart should allow users to opt out of having it.