### PR TITLE
Fixed typo

### DIFF
--- a/idsvr/templates/convertKeystore-conf.yaml
+++ b/idsvr/templates/convertKeystore-conf.yaml
@@ -62,7 +62,7 @@ spec:
       containers:
         - name: {{ $convertKs.sourceTls.keyName | lower | replace "_" "-" }}-keystore-conf-job
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
           command: [ "sh", "/opt/idsvr/bin/convertKeystoreSecret.sh" ]
           env:
             - name: SECRET_NAME


### PR DESCRIPTION
Hmm - my previous change was correct for cluster-conf.yaml, which uses `.Values.image`.
However, convertKeystore-conf.yaml requires `$.Values.image` and I hadn't spotted that.
This caused an error in a repo of mine, so this PR provides a fix.