### PR TITLE
Don't set replica count when using HPA

### DIFF
--- a/idsvr/templates/deployment-runtime.yaml
+++ b/idsvr/templates/deployment-runtime.yaml
@@ -11,7 +11,9 @@ metadata:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "curity.name" . }}


### PR DESCRIPTION
The HPA can conflict with the replica count that's set in the Deployment spec. This is very noticeable when using a system like Argo CD to manage the deployment since it attempts to re-apply the YAML continuously. What happens is that if your replica count in the Deployment doesn't match what the HPA wants to set, the ReplicaSet will be constantly scaled up and down.

This is noted in Argo's documentation [here](https://argo-cd.readthedocs.io/en/stable/user-guide/best_practices/#leaving-room-for-imperativeness), although this is not a situation that this unique to Argo CD.
> It may be desired to leave room for some imperativeness/automation, and not have everything defined in your Git manifests. For example, if you want the number of your deployment's replicas to be managed by [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/), then you would not want to track replicas in Git.
> ```
> apiVersion: apps/v1
> kind: Deployment
> metadata:
>   name: nginx-deployment
> spec:
>   # do not include replicas in the manifests if you want replicas to be controlled by HPA
>   # replicas: 1
> ```

Here are a few examples.
1. If `.Values.autoscaling.minReplicas` is 2, and `.Values.replicaCount` is 2, and the HPA decided to scale to 3, applying `deployment-runtime.yaml` will try to scale back down to 2, and the HPA will keep trying to scale it up to 3.
1. If `.Values.autoscaling.minReplicas` is 2, and `.Values.replicaCount` is 3, and the HPA doesn't try to scale up/down, applying `deployment-runtime.yaml` will try to scale it up to to 3, and the HPA will keep trying to scale it down to 2.
1. If `.Values.autoscaling.minReplicas` is 2, and `.Values.replicaCount` is 1, and the HPA doesn't try to scale up/down, applying `deployment-runtime.yaml` will try to scale down to 1, and the HPA will keep trying to keep it scaled to 2.