### PR TITLE
Add ingressClassName field to Ingress resources. Its value is set to empty by default

### DIFF
--- a/idsvr/Chart.yaml
+++ b/idsvr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: idsvr
-version: 0.12.18
+version: 0.12.19
 appVersion: 8.6.1
 description: A Helm chart for Curity Identity Server
 keywords:

--- a/idsvr/README.md
+++ b/idsvr/README.md
@@ -171,7 +171,7 @@ In the table below you can find information about the parameters that are config
 | `nodeSelector` | Node selector applied in admin and runtime deployments | `{}` |
 | `tolerations` | Tolerations applied in admin and runtime deployments | `{}` |
 | `affinity` | Affinity applied in admin and runtime deployments| `{}` |
-
+| `ingress.ingressClassName` | IngressClassName is the name of an IngressClass cluster resource. Ingress controller use this field to know whether they should be serving this Ingress resource. | `null` |
 
 <b id="f1">1</b> The network policy within the cluster will not have any affect unless there is a network policy
 provider that can enforce network policies. Check out kubernetes official documentation for more guidance on how to

--- a/idsvr/templates/ingress.yaml
+++ b/idsvr/templates/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
       {{- end }}
     {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.ingress.runtime.secretName }}
   tls:
     {{- if .Values.ingress.runtime.secretName }}
@@ -57,6 +60,9 @@ metadata:
       {{- end }}
     {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.ingress.admin.secretName }}
   tls:
     {{- if .Values.ingress.admin.secretName }}

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -197,6 +197,7 @@ ingress:
 #     kubernetes.io/ingress.class: nginx
 #     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 #     kubernetes.io/tls-acme: "true"
+  ingressClassName:
   runtime:
     enabled: false
     tlsHost:


### PR DESCRIPTION
From OpenShift 4.12, it's required to add field ingressClassName to ingress resources, otherwise the alert "IngressWithoutClassName" will be triggered. 