### PR TITLE
Use node selectors in cluster-conf-job

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Quality](https://img.shields.io/badge/quality-test-yellow)](https://curity.io/resources/code-examples/status/)
 [![Availability](https://img.shields.io/badge/availability-source-blue)](https://curity.io/resources/code-examples/status/)
 
-This repository contains the Curity Identity Server helm chart source code. 
+This repository contains the Curity Identity Server helm chart source code.
 
 For more information on Curity and its capabilities, click [here](https://curity.io).
 

--- a/idsvr/README.md
+++ b/idsvr/README.md
@@ -222,12 +222,11 @@ curity:
             items:
             - key: <DATE>-<TRANSACTION_ID>.xml
               path: config-backup.xml
-        
 ```
 
 ```shell script
 helm upgrade <release-name> curity/idsvr -f myValues.xml
-``` 
+```
 
 ## Sending all logs to stdout
 
@@ -294,11 +293,11 @@ curity:
 
 ## Post hook container
 
-Enable the post hook `postHook.enabled=true` to start a post hook container. 
+Enable the post hook `postHook.enabled=true` to start a post hook container.
 
 Example: Post message to slack.
 
-``` 
+```
     postHook:
       enabled: true
       image: nexus.hh.atg.se:17000/curlimages/curl:7.79.1

--- a/idsvr/templates/cluster-conf.yaml
+++ b/idsvr/templates/cluster-conf.yaml
@@ -61,6 +61,10 @@ spec:
           {{- .Values.curity.jobsAnnotations | toYaml | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ include "curity.fullname" . }}-cluster-conf-job
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/idsvr/templates/convertKeystore-conf.yaml
+++ b/idsvr/templates/convertKeystore-conf.yaml
@@ -64,6 +64,10 @@ spec:
           {{- .Values.curity.jobsAnnotations | toYaml | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ $convertKs.sourceTls.keyName | lower | replace "_" "-" }}-keystore-conf-job
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"

--- a/idsvr/templates/convertKeystore-conf.yaml
+++ b/idsvr/templates/convertKeystore-conf.yaml
@@ -29,7 +29,7 @@ data:
 
     openssl pkcs12 -export -name {{ $convertKs.sourceTls.inAlias }} -inkey /var/run/secrets/{{ $convertKs.sourceTls.fromSecretRef }}/tls.key -in /var/run/secrets/{{ $convertKs.sourceTls.fromSecretRef }}/tls.crt -out /var/run/keystore/curity.p12 -password pass:${KEYSTORE_PASSWORD} && openssl base64 -in /var/run/keystore/curity.p12 -out /var/run/keystore/curity.p12-b64 -A
     KEY=$(/opt/idsvr/bin/convertks --in-password ${KEYSTORE_PASSWORD}  --in-alias {{ $convertKs.sourceTls.inAlias }} --in-entry-password ${KEYSTORE_PASSWORD} --in-file /var/run/keystore/curity.p12-b64 | base64 -w 0)
-    
+
     {{- if $convertKs.sourceTls.cert }}
     CERT=$(cat /var/run/secrets/{{ $convertKs.sourceTls.fromSecretRef }}/tls.crt | base64 -w 0)
     {{- end }}

--- a/idsvr/templates/service-admin.yaml
+++ b/idsvr/templates/service-admin.yaml
@@ -34,4 +34,3 @@ spec:
     app.kubernetes.io/name: {{ include "curity.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     role: {{ include "curity.fullname" . }}-admin
-    


### PR DESCRIPTION
If you are using a node selector (for example to choose nodes that match the CPU architecture you require), the cluster-conf-job can fail because it's not respecting the node selectors. This PR fixes that.