### PR TITLE
Add tlsEnabled flag for ingress TLS handling

### DIFF
--- a/idsvr/README.md
+++ b/idsvr/README.md
@@ -150,11 +150,13 @@ In the table below you can find information about the parameters that are config
 | `ingress.runtime.paths` | Paths of the runtime servers that can be accessed externally | `{/}`<sup>[2](#f2)</sup> |
 | `ingress.runtime.pathType` | PathTpe for the paths defined in `ingress.runtime.paths` | `ImplementationSpecific` |
 | `ingress.runtime.secretName` | Secret which contains the tls cert and key for the runtime TLS connection. If not set, the Ingress will be configured for HTTP | `null` |
+| `ingress.runtime.tlsEnabled` | Enables TLS for the ingress when set to `true`. **NOTE:** if set to `false` TLS will still be configured if `ingress.runtime.secretName` is set, this is to keep the old logic and avoid breaking changes | `false` |
 | `ingress.admin.enabled` | Flag to enable/disable an Ingress resource for the admin node | `false` |
 | `ingress.admin.annotations` | Extra annotations for the Ingress resource for the admin node, overrides `ingress.annotations` if set | `{}` |
 | `ingress.admin.host` | Hostname for the admin server (used by the Ingress resource) | `curity-admin.local` |
 | `ingress.admin.tlsHost` | Hostname for the admin server (used by the Ingress resource) to be able to use wildcard as host | `` |
 | `ingress.admin.secretName` | Secret which contains the tls cert and key for the runtime TLS connection. If not set, the Ingress resource will be configured for HTTP | `null` |
+| `ingress.admin.tlsEnabled` | Enables TLS for the ingress when set to `true`. **NOTE:** if set to `false` TLS will still be configured if `ingress.runtime.secretName` is set, this is to keep the old logic and avoid breaking changes | `false` |
 | `ingress.admin.paths` | Paths of the admin node that can be accessed externally | `{/}`<sup>[2](#f2)</sup> |
 | `ingress.admin.pathType` | PathTpe for the paths defined in `ingress.admin.paths` | `ImplementationSpecific` |
 | `resources` | Resource limits applied in admin and runtime deployments | `{}` |

--- a/idsvr/templates/ingress.yaml
+++ b/idsvr/templates/ingress.yaml
@@ -17,9 +17,21 @@ spec:
 {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
 {{- end }}
-{{- if .Values.ingress.runtime.secretName }}
+{{- if .Values.ingress.runtime.tlsEnabled }}
   tls:
+    - hosts:
+      {{- if .Values.ingress.runtime.tlsHost }}
+        - {{ .Values.ingress.runtime.tlsHost }}
+      {{- else }}
+        - {{ .Values.ingress.runtime.host }}
+      {{- end }}
     {{- if .Values.ingress.runtime.secretName }}
+      secretName: {{ .Values.ingress.runtime.secretName }}
+    {{- end }}
+{{- else -}}
+  {{/* Legacy handling if not tlsEnabled is applied */}}
+  {{- if .Values.ingress.runtime.secretName }}
+  tls:
     - hosts:
       {{- if .Values.ingress.runtime.tlsHost }}
         - {{ .Values.ingress.runtime.tlsHost }}
@@ -27,7 +39,7 @@ spec:
         - {{ .Values.ingress.runtime.host }}
       {{- end }}
       secretName: {{ .Values.ingress.runtime.secretName }}
-    {{- end }}
+  {{- end }}
 {{- end }}
   rules:
     - host: {{ .Values.ingress.runtime.host }}
@@ -63,9 +75,21 @@ spec:
 {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
 {{- end }}
-{{- if .Values.ingress.admin.secretName }}
+{{- if .Values.ingress.admin.tlsEnabled }}
   tls:
+    - hosts:
+      {{- if .Values.ingress.admin.tlsHost }}
+        - {{ .Values.ingress.admin.tlsHost }}
+      {{- else }}
+        - {{ .Values.ingress.admin.host }}
+      {{- end }}
     {{- if .Values.ingress.admin.secretName }}
+      secretName: {{ .Values.ingress.admin.secretName }}
+    {{- end }}
+{{- else -}}
+  {{/* Legacy handling if not tlsEnabled is applied */}}
+  {{- if .Values.ingress.runtime.secretName }}
+  tls:
     - hosts:
       {{- if .Values.ingress.admin.tlsHost }}
         - {{ .Values.ingress.admin.tlsHost }}
@@ -73,7 +97,7 @@ spec:
         - {{ .Values.ingress.admin.host}}
       {{- end }}
       secretName: {{ .Values.ingress.admin.secretName }}
-    {{- end }}
+  {{- end }}
 {{- end }}
   rules:
     - host: {{ .Values.ingress.admin.host }}

--- a/idsvr/values.yaml
+++ b/idsvr/values.yaml
@@ -203,6 +203,7 @@ ingress:
   ingressClassName:
   runtime:
     enabled: false
+    tlsEnabled: false
     tlsHost:
     host: curity.local
     annotations: {}
@@ -213,6 +214,7 @@ ingress:
 
   admin:
     enabled: false
+    tlsEnabled: false
     tlsHost:
     host: curity-admin.local
     annotations: {}


### PR DESCRIPTION
To be able to add TLS to an ingress without having a secret (which is a fully valid option see curityio/idsvr-helm#81 for reasoning) this change adds the tlsEnabled flag, which will handle the TLS configuration correct.

If the tlsEnabled is set to false, the legacy TLS logic applies.